### PR TITLE
ci: restrict workflow permissions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ env:
   ASTRO_TELEMETRY_DISABLED: true
   FORCE_COLOR: true
 
+permissions:
+  contents: read
+
 jobs:
   astro:
     name: Astro Check


### PR DESCRIPTION
Resolves the "Workflow does not contain permissions" warnings from the Code Scanning rules. They can be found here: https://github.com/SerenModz21/seren.dev/security/code-scanning