### PR TITLE
ci: update dependency review tag comment to v4.9.0

### DIFF
--- a/.github/workflows/dependency-review.yml
+++ b/.github/workflows/dependency-review.yml
@@ -12,4 +12,4 @@ jobs:
       - name: Checkout Repository
         uses: actions/checkout@de0fac2e4500dabe0009e67214ff5f5447ce83dd # v6
       - name: Dependency Review
-        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4
+        uses: actions/dependency-review-action@2031cfc080254a8a887f58cffee85186f0e49e48 # v4.9.0


### PR DESCRIPTION
The dependency review workflow does not have a v4 tag. As such, causing Renovate to not be able to look it up.

Job logs:
<img width="751" height="197" alt="image" src="https://github.com/user-attachments/assets/7a4351e4-72df-4211-8708-2689b43b3f1b" />

Dependency dashboard:
<img width="815" height="162" alt="image" src="https://github.com/user-attachments/assets/50958754-2c9e-4107-acce-499fe99dc9f1" />
